### PR TITLE
[fix] add tldextract to install_requires #4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="dscanner",
     version="1.0.0",
-    install_requires=["requests", "qrcode"],
+    install_requires=["requests", "qrcode", "tldextract"],
     entry_points={
         "console_scripts": [
             "dscan=dscanner.console_script:main",


### PR DESCRIPTION
dscanner/bit.pyでtldextractをimportしているため、依存ライブラリに追加しました。