### PR TITLE
[fix] #14 add wait time for VirusTotal rate limit to console.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@
 	    ]
 	}
 ## Generate and check domains with Virus Total
-`dscan <domainname> --http --virustotal <here VirusTotal API key>`
+`dscan <domainname> --http --virustotal <here VirusTotal API key>`  
+VERY SLOW.  
 ### Result
+
 	{
 	    "qr": [
 	        {


### PR DESCRIPTION
VirusTotalのrate limitを考慮して、1クエリ投げたら15秒待つように修正しました
制限は4クエリ/分なので、連続で4クエリ投げた後1分待った方が賢いのですが、面倒なのでこうしました。
(どうせ数十クエリ~数百クエリなげるなら、総合でかかる時間は大して変わらない気がするし)
