### PR TITLE
[update] 生成したドメインを名前解決する機能(--ip)を追加 #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,27 @@ Empty `site_threat` means safe.
 	]
 
 
+## Generate and check domains by resolving
+`dscan <domainname> --ip`
+### Result
+
+	generating qr ...
+	generated: 1
+	generating suffix ...
+	generated: 1
+	generating bit ...
+	generated: 1
+	generating typo ...
+	generated: 1
+	fetching domain info ...
+	100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:05<00:00,  1.63s/it]
+	[
+		{
+			"generate_type": [
+				"qr"
+			],
+			"domain_name": "aoogle.com",
+			"ip": "23.253.58.227"
+		},
+		...
+	]

--- a/dscanner/console_script.py
+++ b/dscanner/console_script.py
@@ -38,6 +38,7 @@ def main():
     p.add_argument('-g', '--http', action="store_true", help="Get http response by each candidate domains")
     p.add_argument('--safe_site', default="", help="Get google safe sites tool information. must be followed by api key ")
     p.add_argument('--virustotal', default="", help="Get google safe sites tool information. must be followed by api key. VERY SLOW ")
+    p.add_argument('--ip', action="store_true", help="Get IP address for each candidate domains")
     args = p.parse_args()
 
     # URL候補を取得
@@ -126,6 +127,15 @@ def main():
                         # 制限は1分間に4クエリなのだから、1クエリにつき15秒まつのではなく、4クエリ投げたら1分待つ方が正当だが面倒なのでこうした
                         time.sleep(interval_seconds_virustotal)
                         break
+
+            if args.ip:
+                try:
+                    # 生成したドメインの IP アドレスを取得
+                    ip = socket.gethostbyname(domain_name)
+                except socket.gaierror:
+                    ip = ''
+                finally:
+                    domain_info_dict["ip"] = ip
 
             # 追加例：
             # geoip情報を付加する


### PR DESCRIPTION
--ip オプションをつけると名前解決をして IP アドレスを取得する機能を追加しました．
解決に成功した場合はIPを文字列として表示，失敗した場合は空文字列を表示します．